### PR TITLE
Remove quotes from keycode matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 This was forked from Marcel's repo so that I could add support for the Teensy 3.2 and 4.0. I don't know how to modify the program to eliminate the single quotes around every key code. If anyone can help with this, let me know at thedalles77@gmail.com
 
 
-1. Load the "Matrix_Decoder_LC, _3p2, or 4p0" Arduino code into your Teensy. 
-2. Load the Keyboard_with_number_pad or Keyboard_without_number_pad text file into an editor like Notepad++. 
+1. Load the "Matrix_Decoder_LC, _3p2, or 4p0" Arduino code into your Teensy.
+2. Load the Keyboard_with_number_pad or Keyboard_without_number_pad text file into an editor like Notepad++.
 3. Put the cursor to the right of the first key in the list.
-4. Edit the text file if it's missing any of your keyboards keys. The key codes must be from https://www.pjrc.com/teensy/td_keyboard.html  
+4. Edit the text file if it's missing any of your keyboards keys. The key codes must be from https://www.pjrc.com/teensy/td_keyboard.html
 5. Connect your keyboard FPC cable to the FPC connector.
 6. Hook up the USB cable from your computer to the Teensy.
 7. Wait about 20 seconds, then push each key listed in the text file. You should see pin number pairs as you push a key.
 8. If a listed key is not on your keyboard, use your computer mouse or arrow keys to jump down to the next line.
-9. if you want to assign Media keys (a key event associated with the FN-key), push the media key (do not push the FN key). Add "FN" between the media keyname and the pins. Make sure that there is whitespace between the values. 
+9. if you want to assign Media keys (a key event associated with the FN-key), push the media key (do not push the FN key). Add "FN" between the media keyname and the pins. Make sure that there is whitespace between the values.
 7. Save the finished key list text file.
 8. Make sure the key list text file is in the same folder as the matrixgenerator.py program, then execute the .py program.
 9. The program will create a text file that gives the following:
@@ -19,4 +19,3 @@ This was forked from Marcel's repo so that I could add support for the Teensy 3.
     - Unfortunately the Python program puts single quotes around every item in the Normal, Modifier, and Media arrays.
     - Use an editor to remove all single quotes, then copy these 3 arrays to your USB keyboard code.
 The detailed instructions for modifying the USB keyboard code can be found here: https://github.com/thedalles77/USB_Laptop_Keyboard_Controller/blob/master/Example_Keyboards/Instructions%20for%20modifying%20the%20Teensyduino%20LC%20code.pdf
- 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # USB_Laptop_Keyboard_Controller
-This was forked from Marcel's repo so that I could add support for the Teensy 3.2 and 4.0. I don't know how to modify the program to eliminate the single quotes around every key code. If anyone can help with this, let me know at thedalles77@gmail.com
-
+This was forked from Marcel's repo so that I could add support for the Teensy 3.2 and 4.0. For suggestions and comments, contact me at [thedalles77@gmail.com](thedalles77@gmail.com).
 
 1. Load the "Matrix_Decoder_LC, _3p2, or 4p0" Arduino code into your Teensy.
 2. Load the Keyboard_with_number_pad or Keyboard_without_number_pad text file into an editor like Notepad++.
 3. Put the cursor to the right of the first key in the list.
-4. Edit the text file if it's missing any of your keyboards keys. The key codes must be from https://www.pjrc.com/teensy/td_keyboard.html
+4. Edit the text file if it's missing any of your keyboards keys. The key codes must be from [https://www.pjrc.com/teensy/td_keyboard.html](https://www.pjrc.com/teensy/td_keyboard.html)
 5. Connect your keyboard FPC cable to the FPC connector.
 6. Hook up the USB cable from your computer to the Teensy.
 7. Wait about 20 seconds, then push each key listed in the text file. You should see pin number pairs as you push a key.
@@ -16,6 +15,5 @@ This was forked from Marcel's repo so that I could add support for the Teensy 3.
 9. The program will create a text file that gives the following:
     - The FPC connector pins that are inputs (columns) and the pins that are outputs (rows) in the key matrix.
     - The pins are translated to Teensy I/O numbers so you can add them to your USB keyboard code.
-    - Unfortunately the Python program puts single quotes around every item in the Normal, Modifier, and Media arrays.
-    - Use an editor to remove all single quotes, then copy these 3 arrays to your USB keyboard code.
-The detailed instructions for modifying the USB keyboard code can be found here: https://github.com/thedalles77/USB_Laptop_Keyboard_Controller/blob/master/Example_Keyboards/Instructions%20for%20modifying%20the%20Teensyduino%20LC%20code.pdf
+    - Copy these 3 arrays to your USB keyboard code.
+The detailed instructions for modifying the USB keyboard code can be [found here](https://github.com/thedalles77/USB_Laptop_Keyboard_Controller/blob/master/Example_Keyboards/Instructions%20for%20modifying%20the%20Teensyduino%20LC%20code.pdf).

--- a/matrixgenerator_3p2.py
+++ b/matrixgenerator_3p2.py
@@ -1,6 +1,6 @@
 """
     Copyright 2019 Marcel Hillesheim
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -63,7 +63,7 @@ class Key:
             if(modifiervalue==keytype.name):
                 self.type=keytype
 keys=[]
-    
+
 con_pin=[23, 0, 22, 1, 21, 2, 20, 3, 19, 4, 18, 5, 17, 6, 24, 7, 25, 8, 33, 9, 26, 10, 27, 11, 28, 12, 32, 31, 30, 29, 16, 15, 14, 13]
 #resultlist for inputpins
 inputpins=[]
@@ -175,21 +175,3 @@ for keytype in Keytype:
     matrix=matrix[:-1]+"\n}"
     print(matrix)
 input(seperator+"\nFinished")
-
-        
-            
-            
-
-    
-        
-
-    
-        
-        
-
-
-
-    
-    
-    
-

--- a/matrixgenerator_3p2.py
+++ b/matrixgenerator_3p2.py
@@ -152,7 +152,7 @@ print("\n"+str(len(inputpins))+" inputppins:")
 print(list(map(lambda x: con_pin[x-1], inputpins)))
 print("\n"+str(len(outputpins))+" outputins:")
 print(list(map(lambda x: con_pin[x-1], outputpins)))
-print(seperator+"\nUse an editor to remove all single quotes and then copy these matrices into the Arduino USB Controller code\n")
+print(seperator+"\nCopy these matrices into the Arduino USB Controller code\n")
 # create the different matrices for every keytype
 for keytype in Keytype:
     matrix=seperator+"\n"+keytype.name+"\n"+seperator+"\n{\n"

--- a/matrixgenerator_3p2.py
+++ b/matrixgenerator_3p2.py
@@ -170,7 +170,7 @@ for keytype in Keytype:
                 if (((key.pin1==inputpin) |(key.pin2==inputpin))&((key.pin1==outputpin) | (key.pin2==outputpin))):
                     if key.type==keytype:
                         keylabel=key.label
-            keyrow=keyrow+"'"+keylabel+"',"
+            keyrow=keyrow+keylabel+","
         matrix=matrix+"{"+keyrow[:-1]+"},\n"
     matrix=matrix[:-1]+"\n}"
     print(matrix)

--- a/matrixgenerator_4p0.py
+++ b/matrixgenerator_4p0.py
@@ -152,7 +152,7 @@ print("\n"+str(len(inputpins))+" inputppins:")
 print(list(map(lambda x: con_pin[x-1], inputpins)))
 print("\n"+str(len(outputpins))+" outputins:")
 print(list(map(lambda x: con_pin[x-1], outputpins)))
-print(seperator+"\nUse an editor to remove all single quotes and then copy these matrices into the Arduino USB Controller code\n")
+print(seperator+"\nCopy these matrices into the Arduino USB Controller code\n")
 # create the different matrices for every keytype
 for keytype in Keytype:
     matrix=seperator+"\n"+keytype.name+"\n"+seperator+"\n{\n"

--- a/matrixgenerator_4p0.py
+++ b/matrixgenerator_4p0.py
@@ -1,6 +1,6 @@
 """
     Copyright 2019 Marcel Hillesheim
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -63,7 +63,7 @@ class Key:
             if(modifiervalue==keytype.name):
                 self.type=keytype
 keys=[]
-    
+
 con_pin=[23, 0, 22, 1, 21, 2, 20, 3, 19, 4, 18, 5, 17, 6, 29, 7, 31, 8, 33, 9, 32, 10, 30, 11, 28, 12, 27, 26, 25, 24, 16, 15, 14, 13]
 #resultlist for inputpins
 inputpins=[]
@@ -175,21 +175,3 @@ for keytype in Keytype:
     matrix=matrix[:-1]+"\n}"
     print(matrix)
 input(seperator+"\nFinished")
-
-        
-            
-            
-
-    
-        
-
-    
-        
-        
-
-
-
-    
-    
-    
-

--- a/matrixgenerator_4p0.py
+++ b/matrixgenerator_4p0.py
@@ -170,7 +170,7 @@ for keytype in Keytype:
                 if (((key.pin1==inputpin) |(key.pin2==inputpin))&((key.pin1==outputpin) | (key.pin2==outputpin))):
                     if key.type==keytype:
                         keylabel=key.label
-            keyrow=keyrow+"'"+keylabel+"',"
+            keyrow=keyrow+keylabel+","
         matrix=matrix+"{"+keyrow[:-1]+"},\n"
     matrix=matrix[:-1]+"\n}"
     print(matrix)

--- a/matrixgenerator_LC.py
+++ b/matrixgenerator_LC.py
@@ -1,6 +1,6 @@
 """
     Copyright 2019 Marcel Hillesheim
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -63,7 +63,7 @@ class Key:
             if(modifiervalue==keytype.name):
                 self.type=keytype
 keys=[]
-    
+
 con_pin=[23, 0, 22, 1, 24, 2, 21, 3, 25, 4, 20, 5, 19, 6, 18, 7, 17, 8, 16, 9, 15, 10, 14, 11, 26, 12]
 #resultlist for inputpins
 inputpins=[]
@@ -175,21 +175,3 @@ for keytype in Keytype:
     matrix=matrix[:-1]+"\n}"
     print(matrix)
 input(seperator+"\nFinished")
-
-        
-            
-            
-
-    
-        
-
-    
-        
-        
-
-
-
-    
-    
-    
-

--- a/matrixgenerator_LC.py
+++ b/matrixgenerator_LC.py
@@ -152,7 +152,7 @@ print("\n"+str(len(inputpins))+" inputpins:")
 print(list(map(lambda x: con_pin[x-1], inputpins)))
 print("\n"+str(len(outputpins))+" outputpins:")
 print(list(map(lambda x: con_pin[x-1], outputpins)))
-print(seperator+"\nUse an editor to remove all single quotes and then copy these matrices into the Arduino USB Controller code\n")
+print(seperator+"\nCopy these matrices into the Arduino USB Controller code\n")
 # create the different matrices for every keytype
 for keytype in Keytype:
     matrix=seperator+"\n"+keytype.name+"\n"+seperator+"\n{\n"

--- a/matrixgenerator_LC.py
+++ b/matrixgenerator_LC.py
@@ -170,7 +170,7 @@ for keytype in Keytype:
                 if (((key.pin1==inputpin) |(key.pin2==inputpin))&((key.pin1==outputpin) | (key.pin2==outputpin))):
                     if key.type==keytype:
                         keylabel=key.label
-            keyrow=keyrow+"'"+keylabel+"',"
+            keyrow=keyrow+keylabel+","
         matrix=matrix+"{"+keyrow[:-1]+"},\n"
     matrix=matrix[:-1]+"\n}"
     print(matrix)


### PR DESCRIPTION
Hi @thedalles77 !

Here's a little patch that removes the single quotes when running the Python scripts (you mentioned this in the README).

As I've also reformatted the files I edited (removing spurious spaces and newlines) I've split this patch in small commits to make it easy to read the actual changes.

Actual changes in this patch:

- [x] Updated README removing the notes about the single quotes (commit https://github.com/thedalles77/USB_Laptop_Keyboard_Controller-1/pull/1/commits/75dbbd1504975b4605a4ea53575e921e910297ea)
- [x] Updated the Python scripts removing the single quotes (commit https://github.com/thedalles77/USB_Laptop_Keyboard_Controller-1/pull/1/commits/58c94e038cd3d572a03872a3cc3c723e2c193ef2)

Thank you so much for your guide, it's a great job. I'm working on a keyboard repurposing project based on your guide - I'm still figuring out things, so I'll be back with some questions ;-)

Let me know if something is not clear in this patch or you would like to adjust something